### PR TITLE
Fix undefined variable

### DIFF
--- a/bin/manageSchedule.py
+++ b/bin/manageSchedule.py
@@ -60,7 +60,7 @@ def main():
                 print('ERROR: intervalMask is required for new schedule')
                 exit(1)
 
-            if not croniter.is_valid(intervalMask):
+            if not croniter.is_valid(args.intervalMask):
                 print('ERROR: intervalMask is invalid')
                 exit(1)
 


### PR DESCRIPTION
## Context
Adding a new schedule fails with:
```
  File "/home/pipelinewise/cicada-scheduler/bin/manageSchedule.py", line 63, in main
    if not croniter.is_valid(intervalMask):
NameError: name 'intervalMask' is not defined
```

This is because `intervalMask` is not a defined variable.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
