### PR TITLE
Slack erroring needs re-thinking

### DIFF
--- a/cicada/commands/exec_schedule.py
+++ b/cicada/commands/exec_schedule.py
@@ -210,9 +210,10 @@ def main(schedule_id, dbname=None):
                             db_cur.close()
                             db_conn.close()
                         except Exception as error:
-                            send_slack_error(
-                                schedule_id, schedule_log_id, returncode, error
-                            )
+                            pass
+                            # send_slack_error(
+                            #     schedule_id, schedule_log_id, returncode, error
+                            # )
 
             # Capture error
             except OSError as error:
@@ -236,10 +237,10 @@ def main(schedule_id, dbname=None):
                 for zombie in psutil.Process(cicada_pid).children(recursive=True):
                     zombie.send_signal(signal.SIGKILL)
 
-                if (returncode != 0) and (error_detail != "Cicada abort_running"):
-                    send_slack_error(
-                        schedule_id, schedule_log_id, returncode, error_detail
-                    )
+                # if (returncode != 0) and (error_detail != "Cicada abort_running"):
+                #     send_slack_error(
+                #         schedule_id, schedule_log_id, returncode, error_detail
+                #     )
 
                 # Repeatedly attempt to finalize schedule, even if db is unavailable
                 db_connection_made = False


### PR DESCRIPTION
## Context

Cicada is sending alerts to slack when
1. Cicada itself fails
2. a schedule fails to run

This change disables 2 until it can be updated to send to a separate channel


## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
