### PR TITLE
Should be SIGTERM to ask politely

### DIFF
--- a/cicada/commands/exec_schedule.py
+++ b/cicada/commands/exec_schedule.py
@@ -236,7 +236,7 @@ def main(schedule_id, dbname=None):
 
                 # Terminate any zombie processes
                 for zombie in psutil.Process(cicada_pid).children(recursive=True):
-                    zombie.send_signal(signal.SIGKILL)
+                    zombie.send_signal(signal.SIGTERM)
 
                 # if (returncode != 0) and (error_detail != "Cicada abort_running"):
                 #     send_slack_error(


### PR DESCRIPTION
## Context

Currently the `abort_running` feature uses **SIGKILL** to ask schedules to stop ... this is incorrect and should use **SIGTERM**

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
