### PR TITLE
Only schedule new schedules on enabled servers

### DIFF
--- a/cicada/lib/scheduler.py
+++ b/cicada/lib/scheduler.py
@@ -155,7 +155,9 @@ def insert_schedule_details(db_cur, schedule_details):
             sqlquery + " ,'" + str(schedule_details["schedule_description"]) + "'"
         )
     if schedule_details["server_id"] is None:
-        sqlquery = sqlquery + " ,(select min(server_id) from servers)"
+        sqlquery = (
+            sqlquery + " ,(SELECT MIN(server_id) FROM servers WHERE is_enabled=1)"
+        )
     else:
         sqlquery = sqlquery + " ," + str(schedule_details["server_id"])
     if schedule_details["schedule_order"] is not None:

--- a/tests/test_main_functionality.py
+++ b/tests/test_main_functionality.py
@@ -92,6 +92,10 @@ def test_test_db_setup(db_setup):
 
 def test_register_server():
     """test_register_server"""
+    query_test_db(
+        "INSERT INTO servers (server_id, hostname, fqdn, ip4_address, is_enabled) VALUES (0, 'localhost', 'localhost', '127.0.0.1', 0)"
+    )
+
     register_server.main(pytest.db_test)
 
     hostname = socket.gethostname()
@@ -101,7 +105,7 @@ def test_register_server():
     ip4_address = socket.gethostbyname(fqdn)
 
     results = query_test_db(
-        "SELECT hostname, fqdn, ip4_address, is_enabled FROM servers"
+        f"SELECT hostname, fqdn, ip4_address, is_enabled FROM servers WHERE hostname='{hostname}'"
     )
 
     assert (
@@ -137,8 +141,7 @@ def test_insert_async_schedule():
 
     query_result = query_test_db(
         f"""
-        SELECT schedule_id, schedule_description,
-        (SELECT MIN(server_id) FROM servers) AS server_id,
+        SELECT schedule_id, schedule_description, server_id,
         schedule_order, is_async, is_enabled, adhoc_execute, interval_mask, first_run_date, last_run_date, exec_command, parameters,
         adhoc_parameters, schedule_group_id, is_running
         FROM schedules WHERE schedule_id = '{schedule_details['schedule_id']}'
@@ -191,8 +194,7 @@ def test_update_schedule():
 
     query_result = query_test_db(
         """
-        SELECT schedule_id, schedule_description,
-        (SELECT MIN(server_id) FROM servers) AS server_id,
+        SELECT schedule_id, schedule_description, server_id,
         schedule_order, is_async, is_enabled, adhoc_execute, interval_mask, first_run_date, last_run_date, exec_command, parameters,
         adhoc_parameters, schedule_group_id, is_running
         FROM schedules WHERE schedule_id = 'pytest'
@@ -256,8 +258,7 @@ def test_insert_adhoc_schedule():
 
     query_result = query_test_db(
         f"""
-        SELECT schedule_id, schedule_description,
-        (SELECT MIN(server_id) FROM servers) AS server_id,
+        SELECT schedule_id, schedule_description, server_id,
         schedule_order, is_async, is_enabled, adhoc_execute, interval_mask, first_run_date, last_run_date, exec_command, parameters,
         adhoc_parameters, schedule_group_id, is_running
         FROM schedules WHERE schedule_id = '{schedule_details['schedule_id']}'
@@ -321,8 +322,7 @@ def test_insert_sync_schedule_1():
 
     query_result = query_test_db(
         """
-        SELECT schedule_id, schedule_description,
-        (SELECT MIN(server_id) FROM servers) AS server_id,
+        SELECT schedule_id, schedule_description, server_id,
         schedule_order, is_async, is_enabled, adhoc_execute, interval_mask, first_run_date, last_run_date, exec_command, parameters,
         adhoc_parameters, schedule_group_id, is_running
         FROM schedules WHERE schedule_id = 'pytest1'
@@ -375,8 +375,7 @@ def test_insert_sync_schedule_2():
 
     query_result = query_test_db(
         """
-        SELECT schedule_id, schedule_description,
-        (SELECT MIN(server_id) FROM servers) AS server_id,
+        SELECT schedule_id, schedule_description, server_id,
         schedule_order, is_async, is_enabled, adhoc_execute, interval_mask, first_run_date, last_run_date, exec_command, parameters,
         adhoc_parameters, schedule_group_id, is_running
         FROM schedules WHERE schedule_id = 'pytest2'


### PR DESCRIPTION
## Context

Currently new schedules are scheduled to the lowest server_id, even if that server is disabled
Minor bug fix to schedule to the lowest enabled server_id.

[AP-1117](https://transferwise.atlassian.net/browse/AP-1117)

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
