### PR TITLE
Use server generated uuid1 for greater uniqueness

### DIFF
--- a/cicada/commands/exec_schedule.py
+++ b/cicada/commands/exec_schedule.py
@@ -6,6 +6,7 @@ import psutil
 import os
 import signal
 import time
+import uuid
 
 from cicada.lib import postgres
 from cicada.lib import scheduler
@@ -86,13 +87,8 @@ def unset_abort_running(db_cur, schedule_id):
 
 def init_schedule_log(db_cur, server_id, schedule_id, full_command):
     """Initialise a schedule log"""
-    # Get UUID
-    sqlquery = """
-    SELECT uuid_generate_v1()
-    """
-    db_cur.execute(sqlquery)
-    row = db_cur.fetchone()
-    schedule_log_id = str(row[0])
+    # Get local machine uuid
+    schedule_log_id = uuid.uuid1()
 
     sqlquery = f"""
     INSERT INTO schedule_log

--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,13 @@ setup(
         'pyyaml==6.0',
         'croniter==1.2.0',
         'tabulate==0.8.9',
-        'slack-sdk==3.13.0',
+        'slack-sdk==3.14.1',
         'backoff==1.11.1',
         'psutil==5.9.0',
     ],
     extras_require={
         'dev': [
-            'pytest==6.2.5',
+            'pytest==7.0.1',
             'pytest-cov==3.0.0',
             'pylint==2.12.2',
             'black==22.1.0',


### PR DESCRIPTION
## Context

[AP-1119](https://transferwise.atlassian.net/browse/AP-1119)

Because we are using the central database to generate the uuid, there is no uniqueness on the hostname. This leads to very occasional uuid collisions. By changing to host generated uuid the collisions should be impossible until python is able to launch 2 subprocesses at exactly the same millisecond.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
