### PR TITLE
Don't keep database connection open while execting a schedule

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -32,15 +32,6 @@ unsafe-load-any-extension=no
 # run arbitrary code
 extension-pkg-whitelist=ujson
 
-# Allow optimization of some AST trees. This will activate a peephole AST
-# optimizer, which will apply various small optimizations. For instance, it can
-# be used to obtain the result of joining multiple strings with the addition
-# operator. Joining a lot of strings can lead to a maximum recursion error in
-# Pylint and this flag can prevent that. It has one side effect, the resulting
-# AST will be different than the one from reality.
-optimize-ast=no
-
-
 [MESSAGES CONTROL]
 
 # Only show warnings with the listed confidence levels. Leave empty to show
@@ -68,7 +59,6 @@ enable=import-error,
        used-before-assignment,
        cell-var-from-loop,
        global-variable-undefined,
-       redefine-in-handler,
        unused-import,
        unused-wildcard-import,
        global-variable-not-assigned,
@@ -77,7 +67,7 @@ enable=import-error,
        global-at-module-level,
        bad-open-mode,
        redundant-unittest-assert,
-       boolean-datetime
+       boolean-datetime,
        deprecated-method,
        anomalous-unicode-escape-in-string,
        anomalous-backslash-in-string,
@@ -101,7 +91,7 @@ enable=import-error,
        assert-on-tuple,
        dangerous-default-value,
        duplicate-key,
-       useless-else-on-loop
+       useless-else-on-loop,
        expression-not-assigned,
        confusing-with-statement,
        unnecessary-lambda,
@@ -113,10 +103,6 @@ enable=import-error,
        exec-used,
        using-constant-test,
        bad-super-call,
-       missing-super-argument,
-       slots-on-old-class,
-       super-on-old-class,
-       property-on-old-class,
        not-an-iterable,
        not-a-mapping,
        format-needs-mapping,
@@ -132,36 +118,11 @@ enable=import-error,
        bad-format-string,
        missing-format-attribute,
        missing-format-argument-key,
-       unused-format-string-argument
+       unused-format-string-argument,
        unused-format-string-key,
        invalid-format-index,
        bad-indentation,
-       mixed-indentation,
        unnecessary-semicolon,
-       lowercase-l-suffix,
-       invalid-encoded-data,
-       unpacking-in-except,
-       import-star-module-level,
-       long-suffix,
-       old-octal-literal,
-       old-ne-operator,
-       backtick,
-       old-raise-syntax,
-       metaclass-assignment,
-       next-method-called,
-       dict-iter-method,
-       dict-view-method,
-       indexing-exception,
-       raising-string,
-       using-cmp-argument,
-       cmp-method,
-       coerce-method,
-       delslice-method,
-       getslice-method,
-       hex-method,
-       nonzero-method,
-       t-method,
-       setslice-method,
        logging-format-truncated,
        logging-too-few-args,
        logging-too-many-args,
@@ -206,7 +167,6 @@ enable=import-error,
        raising-non-exception,
        misplaced-bare-raise,
        duplicate-except,
-       nonstandard-exception,
        binary-op-exception,
        bare-except,
        not-async-context-manager,
@@ -243,11 +203,6 @@ enable=import-error,
 # mypackage.mymodule.MyReporterClass.
 output-format=parseable
 
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]".
-files-output=no
-
 # Tells whether to display a full report or only the messages
 reports=no
 
@@ -281,12 +236,6 @@ ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
 single-line-if-stmt=no
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,dict-separator
 
 # Maximum number of lines in a module
 max-module-lines=1000
@@ -382,10 +331,6 @@ notes=FIXME,XXX
 
 
 [BASIC]
-
-# List of builtins function names that should not be used, separated by a comma
-bad-functions=map,filter,input
-
 # Good variable names which should always be accepted, separated by a comma
 good-names=i,j,k,ex,Run,_
 
@@ -402,62 +347,32 @@ include-naming-hint=no
 # Regular expression matching correct function names
 function-rgx=[a-z_][a-z0-9_]{2,40}$
 
-# Naming hint for function names
-function-name-hint=[a-z_][a-z0-9_]{2,40}$
-
 # Regular expression matching correct variable names
 variable-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for variable names
-variable-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
-
 # Regular expression matching correct attribute names
 attr-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for attribute names
-attr-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct argument names
 argument-rgx=[a-z_][a-z0-9_]{2,30}$
 
-# Naming hint for argument names
-argument-name-hint=[a-z_][a-z0-9_]{2,30}$
-
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
-
-# Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
-
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
-
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
 
 # Regular expression matching correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
-# Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
-
 # Regular expression matching correct method names
 method-rgx=[a-z_][a-z0-9_]{2,80}$
-
-# Naming hint for method names
-method-name-hint=[a-z_][a-z0-9_]{2,80}$
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.

--- a/cicada/commands/exec_schedule.py
+++ b/cicada/commands/exec_schedule.py
@@ -153,109 +153,112 @@ def main(schedule_id, dbname=None):
     obj_schedule_details = scheduler.get_schedule_executable(db_cur, schedule_id)
 
     # pylint: disable=too-many-nested-blocks
-    for row in obj_schedule_details.fetchall():
-        command = str(row[0])
-        parameters = str(row[1])
+    row = obj_schedule_details.fetchone()
+    command = str(row[0])
+    parameters = str(row[1])
 
-        full_command = []
-        full_command.extend(command.split())
-        full_command.extend(parameters.split())
+    full_command = []
+    full_command.extend(command.split())
+    full_command.extend(parameters.split())
 
-        human_full_command = str(" ".join(full_command))
+    human_full_command = str(" ".join(full_command))
 
-        # Check to see that schedule is not already running
-        if get_is_running(db_cur, schedule_id) == 0:
-            # Initiate schedule log
-            schedule_log_id = init_schedule_log(
-                db_cur, server_id, schedule_id, human_full_command
+    # Check to see that schedule is not already running
+    if get_is_running(db_cur, schedule_id) == 0:
+        # Initiate schedule log
+        schedule_log_id = init_schedule_log(
+            db_cur, server_id, schedule_id, human_full_command
+        )
+        reset_adhoc_details(db_cur, schedule_id)
+
+        set_is_running(db_cur, schedule_id)
+
+        db_cur.close()
+        db_conn.close()
+
+        signal.signal(signal.SIGTERM, catch_sigterm)
+        signal.signal(signal.SIGQUIT, catch_sigquit)
+
+        cicada_pid = os.getpid()
+
+        error_detail = None
+        returncode = None
+
+        try:
+            # pylint: disable=consider-using-with
+            child_process = subprocess.Popen(
+                full_command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
             )
-            reset_adhoc_details(db_cur, schedule_id)
 
-            set_is_running(db_cur, schedule_id)
+            # Check if child process has terminated
+            while returncode is None:
+                time.sleep(1)
+                returncode = child_process.poll()
 
-            signal.signal(signal.SIGTERM, catch_sigterm)
-            signal.signal(signal.SIGQUIT, catch_sigquit)
-
-            cicada_pid = os.getpid()
-
-            error_detail = None
-            returncode = None
-
-            try:
-                # pylint: disable=consider-using-with
-                child_process = subprocess.Popen(
-                    full_command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-                )
-
-                # Check if child process has terminated
-                while returncode is None:
-                    time.sleep(1)
-                    returncode = child_process.poll()
-
-                    # If still running, check if child_process should be aborted
-                    if returncode is None:
-                        # protect against db unavailable
-                        try:
-                            db_conn = postgres.db_cicada(dbname)
-                            db_cur = db_conn.cursor()
-                            if get_abort_running(db_cur, schedule_id):
-
-                                # Terminate main process
-                                returncode = -15
-                                error_detail = "Cicada abort_running"
-                                unset_abort_running(db_cur, schedule_id)
-                            db_cur.close()
-                            db_conn.close()
-                        # pylint: disable=unused-variable
-                        except Exception as error:
-                            send_slack_error(
-                                schedule_id,
-                                schedule_log_id,
-                                returncode,
-                                "Cicada database not reachable",
-                            )
-                            time.sleep(1)
-
-            # Capture error
-            except OSError as error:
-                returncode = error.errno
-                error_detail = error.strerror
-            except subprocess.CalledProcessError as error:
-                returncode = error.returncode
-                error_detail = "CalledProcessError"
-            except KeyboardInterrupt:
-                returncode = 1
-                error_detail = "KeyboardInterrupt"
-            except SystemExit:
-                returncode = 1
-                error_detail = "SystemExit"
-            except Exception:
-                returncode = 999
-                error_detail = "Crazy Unknown Error"
-            finally:
-
-                # Terminate any zombie processes
-                for zombie in psutil.Process(cicada_pid).children(recursive=True):
-                    zombie.send_signal(signal.SIGTERM)
-
-                # Repeatedly attempt to finalize schedule, even if db is unavailable
-                db_connection_made = False
-                while not db_connection_made:
+                # If still running, check if child_process should be aborted
+                if returncode is None:
+                    # protect against db unavailable
                     try:
                         db_conn = postgres.db_cicada(dbname)
                         db_cur = db_conn.cursor()
-                        db_connection_made = True
-                    except Exception:
+                        if get_abort_running(db_cur, schedule_id):
+
+                            # Terminate main process
+                            returncode = -15
+                            error_detail = "Cicada abort_running"
+                            unset_abort_running(db_cur, schedule_id)
+                        db_cur.close()
+                        db_conn.close()
+                    # pylint: disable=unused-variable
+                    except Exception as error:
                         send_slack_error(
                             schedule_id,
                             schedule_log_id,
                             returncode,
-                            "Cicada database not reachable",
+                            "Cicada database not reachable to check abort_running",
                         )
                         time.sleep(1)
 
-                unset_is_running(db_cur, schedule_id)
-                finalize_schedule_log(db_cur, schedule_log_id, returncode, error_detail)
+        # Capture error
+        except OSError as error:
+            returncode = error.errno
+            error_detail = error.strerror
+        except subprocess.CalledProcessError as error:
+            returncode = error.returncode
+            error_detail = "CalledProcessError"
+        except KeyboardInterrupt:
+            returncode = 1
+            error_detail = "KeyboardInterrupt"
+        except SystemExit:
+            returncode = 1
+            error_detail = "SystemExit"
+        except Exception:
+            returncode = 999
+            error_detail = "Crazy Unknown Error"
+        finally:
+
+            # Terminate any zombie processes
+            for zombie in psutil.Process(cicada_pid).children(recursive=True):
+                zombie.send_signal(signal.SIGTERM)
+
+            # Repeatedly attempt to finalize schedule, even if db is unavailable
+            db_connection_made = False
+            while not db_connection_made:
+                try:
+                    db_conn = postgres.db_cicada(dbname)
+                    db_cur = db_conn.cursor()
+                    db_connection_made = True
+                except Exception:
+                    send_slack_error(
+                        schedule_id,
+                        schedule_log_id,
+                        returncode,
+                        "Cicada database not reachable to finalize schedule",
+                    )
+                    time.sleep(1)
+
+            unset_is_running(db_cur, schedule_id)
+            finalize_schedule_log(db_cur, schedule_log_id, returncode, error_detail)
 
     db_cur.close()
     db_conn.close()

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -42,7 +42,7 @@ $ docker exec -it cicada_dev make pytest
 ###  Running linters
 
 ``` sh
-$ make dev pylint flake8 black
+$ docker exec -it cicada_dev make dev pylint flake8 black
 ```
 
 ### To refresh the containers

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 setup(
     name="cicada",
-    version="0.3.2",
+    version="0.3.3",
     description="Lightweight, agent-based, distributed scheduler",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -20,17 +20,17 @@ setup(
     install_requires=[
         "psycopg2-binary==2.9.3",
         "pyyaml==6.0",
-        "croniter==1.3.4",
+        "croniter==1.3.5",
         "tabulate==0.8.9",
-        "slack-sdk==3.15.2",
-        "backoff==1.11.1",
+        "slack-sdk==3.17.2",
+        "backoff==2.1.2",
         "psutil==5.9.0",
     ],
     extras_require={
         "dev": [
-            "pytest==7.1.1",
+            "pytest==7.1.2",
             "pytest-cov==3.0.0",
-            "pylint==2.13.4",
+            "pylint==2.14.4",
             "black==22.3.0",
             "flake8==4.0.1",
             "freezegun==1.2.1",


### PR DESCRIPTION
## Context

Cicada will open a database connection and keep it open even if it no longer requires any data.
In an environment with thousands of scheduled jobs, this can lead to a lot of idle connections on the back-end database.
The code already opens a new connection when the schedule needs to be finalized.
This bug fix will close the database connection after the schedule information has been extracted.

[AP-1232](https://transferwise.atlassian.net/browse/AP-1232)

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
