### PR TITLE
Alert after 15 minutes of db unavailability

### DIFF
--- a/local-dev/entrypoint.sh
+++ b/local-dev/entrypoint.sh
@@ -102,8 +102,8 @@ echo "List server schedules : cicada list_server_schedules"
 echo
 echo "Run tests in cicada_dev container"
 echo "---------------------------------"
-echo "Run tests             : make dev pytest --file=${CICADA_HOME}/Makefile"
-echo "Run linter            : make dev pylint --file=${CICADA_HOME}/Makefile"
+echo "Run tests             : docker exec -it cicada_dev make pytest"
+echo "Run linters           : docker exec -it cicada_dev make dev pylint flake8 black"
 echo "=========================================================================="
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,10 @@ setup(
         "dev": [
             "pytest==7.1.2",
             "pytest-cov==3.0.0",
-            "pylint==2.14.5",
+            "pylint==2.15.0",
             "black==22.6.0",
-            "flake8==4.0.1",
-            "freezegun==1.2.1",
+            "flake8==5.0.4",
+            "freezegun==1.2.2",
         ]
     },
     entry_points={"console_scripts": ["cicada=cicada.cli:main"]},


### PR DESCRIPTION
## Context

[AP-1269](https://transferwise.atlassian.net/browse/AP-1269) : Cicada auto-heals, but still sends alerts immediately on database unavailability. This changes that to only alert after 15 minutes of database unavailability.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
