### PR TITLE
Add --only_enabled_servers option to spread_schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Cicada scheduler
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 *Centralized Distributed Scheduler*
 
 - [Overview](#overview)

--- a/cicada/cli.py
+++ b/cicada/cli.py
@@ -184,6 +184,12 @@ class Cicada:
             help="List of target server_ids to spread schedules to",
         )
         parser.add_argument(
+            "--exclude_disabled_servers",
+            default=False,
+            action="store_true",
+            help="Exclude disabled servers from target server_ids",
+        )
+        parser.add_argument(
             "--commit",
             default=False,
             action="store_true",

--- a/cicada/commands/spread_schedules.py
+++ b/cicada/commands/spread_schedules.py
@@ -47,13 +47,13 @@ def get_last_week_schedules_by_load(db_cur, server_ids: [int] = None):
     return last_week_schedules_by_load
 
 
-def get_enabled_servers(db_cur, enabled_only: bool = True, server_ids: [int] = None):
+def get_target_servers(db_cur, exclude_disabled, server_ids: [int] = None):
     """Get valid servers"""
-    sql_enabled_filter = " and is_enabled = 1" if enabled_only else ""
+    sql_enabled_filter = " AND is_enabled = 1" if exclude_disabled else ""
     sql_server_id_filter = ""
     if server_ids:
         sql_server_ids = ",".join(str(server_id) for server_id in server_ids)
-        sql_server_id_filter = f" and server_id in ({sql_server_ids})"
+        sql_server_id_filter = f" AND server_id in ({sql_server_ids})"
 
     sqlquery = f"""
     SELECT server_id FROM servers
@@ -81,7 +81,7 @@ def main(spread_details, dbname=None):
     from_server_ids = csv_to_list(spread_details["from_server_ids"])
     to_server_ids = csv_to_list(spread_details["to_server_ids"])
 
-    valid_target_servers = get_enabled_servers(db_cur, server_ids=to_server_ids)
+    valid_target_servers = get_target_servers(db_cur, spread_details["exclude_disabled_servers"], to_server_ids)
     valid_server_count = len(valid_target_servers)
 
     if valid_server_count == 0:

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -36,7 +36,7 @@ check the [local-dev/.env](../local-dev/.env) file for the credentials.
 ###  Running tests
 
 ``` sh
-$ docker exec -it cicada_dev make pytest
+$ docker exec -it cicada_dev make dev pytest
 ```
 
 ###  Running linters

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 setup(
     name="cicada",
-    version="0.4.0",
+    version="0.4.1",
     description="Lightweight, agent-based, distributed scheduler",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -20,17 +20,17 @@ setup(
     install_requires=[
         "psycopg2-binary==2.9.5",
         "pyyaml==6.0",
-        "croniter==1.3.7",
+        "croniter==1.3.8",
         "tabulate==0.9.0",
-        "slack-sdk==3.19.1",
+        "slack-sdk==3.19.5",
         "backoff==2.2.1",
     ],
     extras_require={
         "dev": [
-            "pytest==7.1.3",
+            "pytest==7.2.0",
             "pytest-cov==4.0.0",
-            "black==22.10.0",
-            "flake8==5.0.4",
+            "black==22.12.0",
+            "flake8==6.0.0",
             "freezegun==1.2.2",
         ]
     },

--- a/tests/test_functional_cli_entrypoint.py
+++ b/tests/test_functional_cli_entrypoint.py
@@ -194,7 +194,8 @@ def test_spread_schedules():
     actual = subprocess.run(["cicada", "spread_schedules"], check=False, stderr=subprocess.PIPE).stderr.decode("utf-8")
 
     expected = """usage: spread_schedules [-h] --from_server_ids FROM_SERVER_IDS --to_server_ids
-                        TO_SERVER_IDS [--commit] [--force]
+                        TO_SERVER_IDS [--exclude_disabled_servers] [--commit]
+                        [--force]
 spread_schedules: error: the following arguments are required: --from_server_ids, --to_server_ids
 """
 
@@ -208,7 +209,8 @@ def test_spread_schedules_help():
     )
 
     expected = """usage: spread_schedules [-h] --from_server_ids FROM_SERVER_IDS --to_server_ids
-                        TO_SERVER_IDS [--commit] [--force]
+                        TO_SERVER_IDS [--exclude_disabled_servers] [--commit]
+                        [--force]
 
 Spread schedules accross servers
 
@@ -218,6 +220,8 @@ optional arguments:
                         List of source server_ids to collect schedules from
   --to_server_ids TO_SERVER_IDS
                         List of target server_ids to spread schedules to
+  --exclude_disabled_servers
+                        Exclude disabled servers from target server_ids
   --commit              Commits changes to backend DB, otherwise only print
                         output
   --force               If schedule is moving servers and also currently


### PR DESCRIPTION
## Context

Add `--only_enabled_servers` option to `spread_schedules`

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 

```
---------- coverage: platform linux, python 3.8.16-final-0 ---
Name                                       Stmts   Miss  Cover
--------------------------------------------------------------
cicada/__init__.py                             1      0   100
cicada/cli.py                                 93      9    90%
cicada/commands/__init__.py                    0      0   100
cicada/commands/archive_schedule_log.py       13      2    85%
cicada/commands/exec_schedule.py             128     26    80%
cicada/commands/exec_server_schedules.py      19      0   100
cicada/commands/list_server_schedules.py      37     31    16%
cicada/commands/ping_slack.py                  3      1    67%
cicada/commands/register_server.py            12      0   100
cicada/commands/show_schedule.py              16      9    44%
cicada/commands/spread_schedules.py           65      5    92%
cicada/commands/upsert_schedule.py            62     18    71%
cicada/lib/__init__.py                         0      0   100
cicada/lib/postgres.py                        15      0   100
cicada/lib/scheduler.py                      171     17    90%
cicada/lib/utils.py                           38     10    74%
--------------------------------------------------------------
TOTAL                                        673    128    81%

Required test coverage of 80% reached. Total coverage: 80.98%
```
