### PR TITLE
relax text limits in schedules tables

### DIFF
--- a/setup/schema.sql
+++ b/setup/schema.sql
@@ -51,7 +51,7 @@ CREATE TABLE IF NOT EXISTS public.schedules
 (
   auto_update_time timestamp without time zone NOT NULL DEFAULT (now())::timestamp without time zone,
   schedule_id character varying(255) NOT NULL DEFAULT uuid_generate_v1(),
-  schedule_description character varying(255),
+  schedule_description character varying(1024),
   server_id integer NOT NULL,
   schedule_order integer NOT NULL DEFAULT 1,
   is_async smallint NOT NULL DEFAULT 1,
@@ -62,9 +62,9 @@ CREATE TABLE IF NOT EXISTS public.schedules
   interval_mask character varying(32) NOT NULL,
   first_run_date timestamp(3) without time zone NOT NULL DEFAULT '1000-01-01 00:00:00.000'::timestamp without time zone,
   last_run_date timestamp(3) without time zone NOT NULL DEFAULT '9999-12-31 23:59:59.999'::timestamp without time zone,
-  exec_command character varying(1024) NOT NULL,
-  parameters character varying(255),
-  adhoc_parameters character varying(255),
+  exec_command character varying() NOT NULL,
+  parameters character varying(),
+  adhoc_parameters character varying(),
   schedule_group_id integer,
   CONSTRAINT schedules_pkey PRIMARY KEY (schedule_id),
   CONSTRAINT schedules_server_id_fkey FOREIGN KEY (server_id)


### PR DESCRIPTION
## Context

Some advanced schedules requires longer command line string than currently allowed in the database, so we are relaxing them

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
