### PR TITLE
Switch to using `sslmode=require` for connections to backend DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.8.3
+-----
+- Switch to using `sslmode=require` for connections to backend DB
+
+0.8.2
+-----
+- Switch to new PyPi publish method
+
 0.8.1
 -----
 - Switch to using `sslmode=prefer` for connections to backend DB

--- a/cicada/lib/postgres.py
+++ b/cicada/lib/postgres.py
@@ -19,7 +19,9 @@ def db_cicada(dbname=None):
     user = definitions["db_cicada"]["user"]
     password = definitions["db_cicada"]["password"]
 
-    conn = psycopg2.connect(host=host, port=port, dbname=dbname, user=user, password=password, sslmode="prefer")
+    conn = psycopg2.connect(
+        host=host, port=port, dbname=dbname, user=user, password=password, sslmode="require", application_name="cicada"
+    )
     conn.autocommit = True
 
     return conn

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 setup(
     name="cicada",
-    version="0.8.2",
+    version="0.8.3",
     description="Lightweight, agent-based, distributed scheduler",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -22,7 +22,7 @@ setup(
         "pyyaml==6.0.*",
         "croniter==2.0.*",
         "tabulate==0.9.*",
-        "slack-sdk==3.30.*",
+        "slack-sdk==3.31.*",
         "backoff==2.2.*",
     ],
     extras_require={


### PR DESCRIPTION
## Context

[AP-1764](https://transferwise.atlassian.net/browse/AP-1764) : Switch to using `sslmode=require` for connections to backend DB

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 


[AP-1764]: https://transferwise.atlassian.net/browse/AP-1764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ