### PR TITLE
169 - Wait for aborted process exit before finalising schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+0.10.4
+------
+
+Runtime
+~~~~~~~
+- After an `abort_running` request, keep the schedule marked as running until its process has stopped
+- Clear additional abort requests while the process is stopping so they do not stop the next run
+
+Tests and CI
+~~~~~~~~~~~~
+- Add coverage that an aborted schedule is finalized only after its process exits
+- Update the existing abort test to confirm the running and abort flags are cleared after process exit
+- Set the minimum test coverage to 75%
+
+
 0.10.3
 ------
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ dev:
 pytest:
 	cd $(mkfile_path) ;\
 	. venv/bin/activate ;\
-	pytest tests/ --verbose --cov=cicada --cov-fail-under=78 --cov-report term-missing
+	pytest tests/ --verbose --cov=cicada --cov-fail-under=75 --cov-report term-missing
 
 
 flake8:

--- a/cicada/commands/exec_schedule.py
+++ b/cicada/commands/exec_schedule.py
@@ -175,6 +175,7 @@ def main(schedule_id, dbname=None):
 
         error_detail = None
         returncode = None
+        abort_running_received = False
 
         db_conn_alert_delay = 15
         db_conn_alert_next = datetime.datetime.utcnow() + datetime.timedelta(minutes=db_conn_alert_delay)
@@ -186,20 +187,23 @@ def main(schedule_id, dbname=None):
 
             while returncode is None:
                 time.sleep(1)
-                returncode = child_process.poll()
+                child_returncode = child_process.poll()
+
+                if child_returncode is not None:
+                    returncode = -15 if abort_running_received else child_returncode
 
                 # If still running, check if child_process should be aborted
-                if returncode is None:
+                else:
                     # protect against db unavailable
                     try:
                         db_conn = postgres.db_cicada(dbname)
                         db_cur = db_conn.cursor()
                         if get_abort_running(db_cur, schedule_id):
-                            # Terminate main process
-                            returncode = -15
-                            error_detail = "Cicada abort_running"
                             unset_abort_running(db_cur, schedule_id)
-                            child_process.terminate()
+                            if not abort_running_received:
+                                abort_running_received = True
+                                error_detail = "Cicada abort_running"
+                                child_process.terminate()
 
                         db_cur.close()
                         db_conn.close()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 setup(
     name="cicada",
-    version="0.10.3",
+    version="0.10.4",
     description="Lightweight, agent-based, distributed scheduler",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_exec_schedule.py
+++ b/tests/test_exec_schedule.py
@@ -1,0 +1,63 @@
+"""Focused tests for schedule process supervision."""
+
+from unittest.mock import MagicMock
+
+from cicada.commands import exec_schedule
+
+
+def test_abort_waits_for_child_exit_before_clearing_running_state(mocker):
+    """Keep a schedule running until its aborted child process exits."""
+    events = []
+    db_connection = MagicMock()
+    db_cursor = db_connection.cursor.return_value
+    schedule_executable = MagicMock()
+    schedule_executable.fetchone.return_value = ("example-command", "example-parameter")
+    child_process = MagicMock()
+    child_returncodes = iter([None, None, 143])
+
+    def poll_child_process():
+        returncode = next(child_returncodes)
+        if returncode is not None:
+            events.append("child_exit")
+        return returncode
+
+    child_process.poll.side_effect = poll_child_process
+    child_process.terminate.side_effect = lambda: events.append("terminate")
+
+    mocker.patch.object(exec_schedule.postgres, "db_cicada", return_value=db_connection)
+    mocker.patch.object(exec_schedule.scheduler, "get_server_id", return_value=1)
+    mocker.patch.object(exec_schedule.scheduler, "get_schedule_executable", return_value=schedule_executable)
+    mocker.patch.object(exec_schedule.scheduler, "get_full_command", return_value=["example-command"])
+    mocker.patch.object(exec_schedule, "get_is_running", return_value=0)
+    mocker.patch.object(exec_schedule, "init_schedule_log", return_value="schedule-log-id")
+    mocker.patch.object(exec_schedule, "reset_adhoc_details")
+    mocker.patch.object(exec_schedule, "set_is_running")
+    mocker.patch.object(exec_schedule, "get_abort_running", side_effect=[True, True])
+    unset_abort_running = mocker.patch.object(exec_schedule, "unset_abort_running")
+    unset_is_running = mocker.patch.object(
+        exec_schedule,
+        "unset_is_running",
+        side_effect=lambda *_: events.append("unset_is_running"),
+    )
+    finalize_schedule_log = mocker.patch.object(
+        exec_schedule,
+        "finalize_schedule_log",
+        side_effect=lambda *_: events.append("finalize_schedule_log"),
+    )
+    mocker.patch.object(exec_schedule.subprocess, "Popen", return_value=child_process)
+    mocker.patch.object(exec_schedule.signal, "signal")
+    mocker.patch.object(exec_schedule.time, "sleep")
+    mocker.patch.object(exec_schedule.utils, "load_config", return_value={"slack": {"returncodes_alert": []}})
+
+    exec_schedule.main("example-schedule")
+
+    assert events == ["terminate", "child_exit", "unset_is_running", "finalize_schedule_log"]
+    child_process.terminate.assert_called_once_with()
+    assert unset_abort_running.call_count == 2
+    unset_is_running.assert_called_once_with(db_cursor, "example-schedule")
+    finalize_schedule_log.assert_called_once_with(
+        db_cursor,
+        "schedule-log-id",
+        -15,
+        "Cicada abort_running",
+    )

--- a/tests/test_functional_main.py
+++ b/tests/test_functional_main.py
@@ -658,10 +658,20 @@ def test_exec_abort_running_2():
     query_test_db("UPDATE schedules SET abort_running=1 WHERE schedule_id='pytest_abort_running_2'")
     time.sleep(10)
     query_result = query_test_db(
-        """SELECT schedule_id, returncode, error_detail FROM schedule_log WHERE schedule_id = 'pytest_abort_running_2'"""
+        """
+        SELECT
+            schedule_log.schedule_id,
+            schedule_log.returncode,
+            schedule_log.error_detail,
+            schedules.is_running,
+            schedules.abort_running
+        FROM schedule_log
+        INNER JOIN schedules USING (schedule_id)
+        WHERE schedule_log.schedule_id = 'pytest_abort_running_2'
+        """
     )
 
-    assert query_result == [("pytest_abort_running_2", -15, "Cicada abort_running")]
+    assert query_result == [("pytest_abort_running_2", -15, "Cicada abort_running", 0, 0)]
 
 
 def test_insert_faulty_schedule_1():


### PR DESCRIPTION
Related to [AP-2830](https://transferwise.atlassian.net/browse/AP-2830)

## Context

Cicada currently clears `is_running` and finalizes the schedule log immediately after `abort_running` sends `SIGTERM`, even though the launched process may still be running.

This is a minimal, human-reviewable alternative to #167 and is intended to replace it. It starts from current `main` and implements only the essential wait-for-exit behavior, without the broader process-supervision refactor from #167.

Refer to [0.10.4 CHANGELOG](https://github.com/transferwise/cicada/blob/7588edbd662613571dfdf110590eebabed8bb3fd/CHANGELOG.md#0104) for full details.

## Changes

- Keep an aborted schedule marked as running until its launched process exits.
- Clear additional abort requests while the process is stopping so they cannot affect the next run.

## Test coverage

- **Existing:** 2 cases related to `abort_running`, 5 covering broader `exec_schedule` behavior.
- **New:** 1 case related to `abort_running`, 0 covering broader `exec_schedule` behavior.
- **Updated:** 1 case related to `abort_running`, 0 covering broader `exec_schedule` behavior. It now confirms `is_running` and `abort_running` are cleared after the process exits.
- **Deleted:** None.

## Validation

- `make pytest`: 142 passed, 78.12% coverage
- `make flake8`: passed with 0 errors
- `make black`: passed

[AP-2830](https://transferwise.atlassian.net/browse/AP-2830)


[AP-2830]: https://transferwise.atlassian.net/browse/AP-2830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ