### PR TITLE
AP-2830: Capture failed process error output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Runtime
 ~~~~~~~
 - Include the launched process's error output in failed schedule records and Slack alerts
-- Show the error output immediately after the return code in Slack alerts
+- Show `error_detail` immediately after the return code in Slack alerts and omit empty context
 
 Tests
 ~~~~~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+0.10.6
+------
+
+Runtime
+~~~~~~~
+- Include the launched process's error output in failed schedule records and Slack alerts
+
+Tests
+~~~~~
+- Add coverage for capturing and bounding launched process error output
+- Add coverage that large error output cannot block process completion
+- Update the faulty-command case to verify its error output is saved
+
+
 0.10.5
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 Runtime
 ~~~~~~~
 - Include the launched process's error output in failed schedule records and Slack alerts
+- Show the error output immediately after the return code in Slack alerts
 
 Tests
 ~~~~~
 - Add coverage for capturing and bounding launched process error output
 - Add coverage that large error output cannot block process completion
 - Update the faulty-command case to verify its error output is saved
+- Update the Slack alert case to verify diagnostic details are shown in sequence
 
 
 0.10.5

--- a/cicada/commands/exec_schedule.py
+++ b/cicada/commands/exec_schedule.py
@@ -128,19 +128,24 @@ def finalize_schedule_log(db_cur, schedule_log_id, returncode, error_detail):
     )
 
 
-def send_slack_error(schedule_id, server_id, interval_mask, schedule_log_id, returncode, description, error):
-    """send_slack_error"""
-    utils.send_slack_message(
-        f":exclamation: *ERROR* schedule_id `{schedule_id}` execution failure",
+def send_slack_error(schedule_id, server_id, interval_mask, schedule_log_id, returncode, context, error_detail):
+    """Send a schedule execution error with its diagnostic context."""
+    details = (
         f"```"
         f"server utc time : {datetime.datetime.utcnow()}\n"
         f"schedule_log_id : {schedule_log_id}\n"
         f"server_id       : {server_id}\n"
         f"interval_mask   : {interval_mask}\n"
         f"returncode      : {returncode}\n"
-        f"error           : {error}\n"
-        f"description     : {description}"
-        f"```",
+        f"error_detail    : {error_detail}"
+    )
+    if context is not None:
+        details += f"\ncontext         : {context}"
+    details += "```"
+
+    utils.send_slack_message(
+        f":exclamation: *ERROR* schedule_id `{schedule_id}` execution failure",
+        details,
         "danger",
     )
 

--- a/cicada/commands/exec_schedule.py
+++ b/cicada/commands/exec_schedule.py
@@ -138,9 +138,8 @@ def send_slack_error(schedule_id, server_id, interval_mask, schedule_log_id, ret
         f"server_id       : {server_id}\n"
         f"interval_mask   : {interval_mask}\n"
         f"returncode      : {returncode}\n"
-        f"description     : {description}\n"
-        f"\n"
-        f"error           : {error}"
+        f"error           : {error}\n"
+        f"description     : {description}"
         f"```",
         "danger",
     )
@@ -370,6 +369,7 @@ def run_child_process(
         schedule_log_id,
         alert_next,
     )
+    # A descendant may inherit stderr after the supervised child exits, so do not wait indefinitely for pipe EOF.
     stderr_reader.join(timeout=CHILD_STDERR_DRAIN_TIMEOUT_SECONDS)
 
     if execution_result.returncode != 0 and execution_result.error_detail is None:

--- a/cicada/commands/exec_schedule.py
+++ b/cicada/commands/exec_schedule.py
@@ -3,6 +3,7 @@
 import datetime
 import subprocess
 import signal
+import threading
 import time
 import uuid
 from typing import NamedTuple, Optional
@@ -15,6 +16,8 @@ from cicada.lib import utils
 DB_ALERT_DELAY_MINUTES = 15
 DB_RETRY_DELAY_SECONDS = 5
 CHILD_WAIT_TIMEOUT_SECONDS = 1
+CHILD_STDERR_CAPTURE_MAX_BYTES = 4096
+CHILD_STDERR_DRAIN_TIMEOUT_SECONDS = 1
 UNKNOWN_RETURN_CODE = 999
 ERROR_DETAIL_MAX_LENGTH = 255
 
@@ -240,6 +243,30 @@ def execution_result_from_exception(error):
     return ExecutionResult(UNKNOWN_RETURN_CODE, str(error) or error.__class__.__name__)
 
 
+def capture_stream_tail(stream, captured, max_bytes=CHILD_STDERR_CAPTURE_MAX_BYTES):
+    """Drain a binary stream while retaining only its most recent bytes."""
+    try:
+        while True:
+            chunk = stream.read(1024)
+            if not chunk:
+                return
+            captured.extend(chunk)
+            if len(captured) > max_bytes:
+                del captured[:-max_bytes]
+    except (OSError, ValueError):
+        return
+    finally:
+        stream.close()
+
+
+def stderr_error_detail(captured):
+    """Return a bounded child error suitable for schedule_log and Slack."""
+    detail = bytes(captured).decode("utf-8", errors="replace").strip()
+    if not detail:
+        return None
+    return detail[-ERROR_DETAIL_MAX_LENGTH:]
+
+
 def supervise_child_process(
     child_process,
     shutdown_request,
@@ -324,8 +351,16 @@ def run_child_process(
     alert_next,
 ):
     """Launch one child and retain supervision until its exit is confirmed."""
-    child_process = subprocess.Popen(full_command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    return supervise_child_process(
+    child_process = subprocess.Popen(full_command, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    captured_stderr = bytearray()
+    stderr_reader = threading.Thread(
+        target=capture_stream_tail,
+        args=(child_process.stderr, captured_stderr),
+        daemon=True,
+    )
+    stderr_reader.start()
+
+    execution_result, alert_next = supervise_child_process(
         child_process,
         shutdown_request,
         dbname,
@@ -335,6 +370,12 @@ def run_child_process(
         schedule_log_id,
         alert_next,
     )
+    stderr_reader.join(timeout=CHILD_STDERR_DRAIN_TIMEOUT_SECONDS)
+
+    if execution_result.returncode != 0 and execution_result.error_detail is None:
+        execution_result = ExecutionResult(execution_result.returncode, stderr_error_detail(captured_stderr))
+
+    return execution_result, alert_next
 
 
 def finalize_schedule_with_retry(
@@ -441,7 +482,7 @@ def main(schedule_id, dbname=None):
                             schedule_log_id,
                             execution_result.returncode,
                             None,
-                            None,
+                            execution_result.error_detail,
                         )
 
         except (Exception, KeyboardInterrupt, SystemExit) as error:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 setup(
     name="cicada",
-    version="0.10.5",
+    version="0.10.6",
     description="Lightweight, agent-based, distributed scheduler",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_exec_schedule.py
+++ b/tests/test_exec_schedule.py
@@ -4,6 +4,8 @@ import datetime
 import signal
 import socket
 import subprocess
+import sys
+from io import BytesIO
 from unittest.mock import MagicMock
 
 import pytest
@@ -24,6 +26,7 @@ def _run_schedule(
     signal_handlers=None,
     events=None,
     signal_during_set=False,
+    child_stderr=b"",
 ):
     """Run one mocked schedule and return its lifecycle collaborators."""
     db_cursor = MagicMock()
@@ -78,6 +81,7 @@ def _run_schedule(
         load_config = mocker.patch.object(exec_schedule.utils, "load_config", side_effect=config)
     else:
         load_config = mocker.patch.object(exec_schedule.utils, "load_config", return_value=config)
+    child_process.stderr = BytesIO(child_stderr)
 
     exec_schedule.main("example-schedule")
 
@@ -172,6 +176,84 @@ def test_natural_child_exit_does_not_request_termination(mocker):
         0,
         None,
     )
+
+
+def test_failed_child_stderr_is_saved_and_sent_to_slack(mocker):
+    """A Docker launch error is retained in schedule_log and its Slack alert."""
+    child_process = MagicMock()
+    child_process.wait.return_value = 125
+    docker_error = (
+        b'docker: Error response from daemon: Conflict. The container name "pipelinewise-tap-one" is in use.\n'
+    )
+
+    collaborators = _run_schedule(
+        mocker,
+        child_process,
+        {"slack": {"returncodes_alert": "*"}},
+        [],
+        child_stderr=docker_error,
+    )
+
+    error_detail = docker_error.decode().strip()
+    collaborators["finalize_schedule_log"].assert_called_once_with(
+        mocker.ANY,
+        "schedule-log-id",
+        125,
+        error_detail,
+    )
+    collaborators["send_slack_error"].assert_called_once_with(
+        "example-schedule",
+        1,
+        "*/5 * * * *",
+        "schedule-log-id",
+        125,
+        None,
+        error_detail,
+    )
+
+
+def test_failed_child_stderr_is_bounded(mocker):
+    """Only the final database-sized portion of verbose child stderr is retained."""
+    child_process = MagicMock()
+    child_process.wait.return_value = 125
+    final_error = b"final Docker error"
+
+    collaborators = _run_schedule(
+        mocker,
+        child_process,
+        {"slack": {"returncodes_alert": []}},
+        [],
+        child_stderr=(b"x" * (exec_schedule.CHILD_STDERR_CAPTURE_MAX_BYTES + 1000)) + final_error,
+    )
+
+    error_detail = collaborators["finalize_schedule_log"].call_args.args[3]
+    assert len(error_detail) == exec_schedule.ERROR_DETAIL_MAX_LENGTH
+    assert error_detail.endswith(final_error.decode())
+
+
+def test_large_child_stderr_is_drained_without_blocking(mocker):
+    """A child can exceed the OS pipe buffer and still exit cleanly."""
+    mocker.patch.object(exec_schedule, "consume_abort_running", return_value=False)
+    final_error = "final Docker error"
+
+    execution_result, _ = exec_schedule.run_child_process(
+        [
+            sys.executable,
+            "-c",
+            f"import sys; sys.stderr.write('x' * 100000 + {final_error!r}); raise SystemExit(125)",
+        ],
+        {"signal": None},
+        None,
+        "example-schedule",
+        1,
+        "*/5 * * * *",
+        "schedule-log-id",
+        datetime.datetime.utcnow(),
+    )
+
+    assert execution_result.returncode == 125
+    assert len(execution_result.error_detail) == exec_schedule.ERROR_DETAIL_MAX_LENGTH
+    assert execution_result.error_detail.endswith(final_error)
 
 
 def test_failed_termination_is_retried_while_supervision_continues(mocker):

--- a/tests/test_exec_schedule.py
+++ b/tests/test_exec_schedule.py
@@ -602,8 +602,23 @@ def test_slack_error_includes_server_and_interval(mocker):
     assert message.index("schedule_log_id") < message.index("server_id")
     assert message.index("server_id") < message.index("interval_mask")
     assert message.index("interval_mask") < message.index("returncode")
-    assert message.index("returncode") < message.index("error")
-    assert message.index("error") < message.index("description")
+    assert message.index("returncode") < message.index("error_detail")
+    assert "error_detail    : process error" in message
+    assert "context" not in message
+
+    exec_schedule.send_slack_error(
+        "example-schedule",
+        7,
+        "*/5 * * * *",
+        "schedule-log-id",
+        125,
+        "Cicada db unavailable - finalize schedule - 15 minutes",
+        "database unavailable",
+    )
+
+    message = send_slack_message.call_args.args[1]
+    assert message.index("error_detail") < message.index("context")
+    assert "context         : Cicada db unavailable - finalize schedule - 15 minutes" in message
 
 
 def test_db_unavailable_alert_is_rate_limited_and_consistent(mocker):

--- a/tests/test_exec_schedule.py
+++ b/tests/test_exec_schedule.py
@@ -582,7 +582,7 @@ def test_db_cursor_creation_failure_closes_connection(mocker):
 
 
 def test_slack_error_includes_server_and_interval(mocker):
-    """Execution alerts identify the server and schedule interval."""
+    """Execution alerts present schedule context and error details in diagnostic order."""
     send_slack_message = mocker.patch.object(exec_schedule.utils, "send_slack_message")
 
     exec_schedule.send_slack_error(
@@ -592,7 +592,7 @@ def test_slack_error_includes_server_and_interval(mocker):
         "schedule-log-id",
         125,
         None,
-        None,
+        "process error",
     )
 
     message = send_slack_message.call_args.args[1]
@@ -601,6 +601,9 @@ def test_slack_error_includes_server_and_interval(mocker):
     assert message.index("server utc time") < message.index("schedule_log_id")
     assert message.index("schedule_log_id") < message.index("server_id")
     assert message.index("server_id") < message.index("interval_mask")
+    assert message.index("interval_mask") < message.index("returncode")
+    assert message.index("returncode") < message.index("error")
+    assert message.index("error") < message.index("description")
 
 
 def test_db_unavailable_alert_is_rate_limited_and_consistent(mocker):

--- a/tests/test_functional_main.py
+++ b/tests/test_functional_main.py
@@ -767,7 +767,13 @@ def test_exec_faulty_schedule_2():
         """SELECT schedule_id, returncode, error_detail FROM schedule_log WHERE schedule_id = 'pytest_faulty_2'"""
     )
 
-    assert query_result == [("pytest_faulty_2", 1, None)]
+    assert query_result == [
+        (
+            "pytest_faulty_2",
+            1,
+            "/usr/bin/sleep: missing operand\nTry '/usr/bin/sleep --help' for more information.",
+        )
+    ]
 
 
 def test_db_teardown():

--- a/tests/test_functional_main.py
+++ b/tests/test_functional_main.py
@@ -767,13 +767,12 @@ def test_exec_faulty_schedule_2():
         """SELECT schedule_id, returncode, error_detail FROM schedule_log WHERE schedule_id = 'pytest_faulty_2'"""
     )
 
-    assert query_result == [
-        (
-            "pytest_faulty_2",
-            1,
-            "/usr/bin/sleep: missing operand\nTry '/usr/bin/sleep --help' for more information.",
-        )
-    ]
+    assert len(query_result) == 1
+    schedule_id, returncode, error_detail = query_result[0]
+    assert schedule_id == "pytest_faulty_2"
+    assert returncode == 1
+    assert error_detail is not None
+    assert "missing operand" in error_detail
 
 
 def test_db_teardown():

--- a/tests/utils/mocks_for_alert.py
+++ b/tests/utils/mocks_for_alert.py
@@ -1,6 +1,10 @@
+from io import BytesIO
+
+
 class MockPopen:
     def __init__(self, return_code, *args, **kwargs):
         self.return_code = return_code
+        self.stderr = BytesIO()
 
     def wait(self, timeout=None):
         return self.return_code


### PR DESCRIPTION
## Context

Cicada records a process return code but discards its stderr. Docker launch failures therefore appear only as return code 125, without the error needed to distinguish daemon connectivity, container-name conflicts, missing images, or invalid runtime configuration.

## Changes

- Record bounded process error output for failed schedules.
- Show the captured error immediately after the return code in Slack failure alerts.
- Preserve existing child supervision, abort handling, and signal behaviour.

Refer to [0.10.6 CHANGELOG](https://github.com/transferwise/cicada/blob/936b365003592216c074a9d16ef8d03fc260c808/CHANGELOG.md#0106) for full details.

## Test summary

- **Existing:** 4 cases related to failed execution alerts and error details; 157 broader Cicada cases.
- **New:** 3 cases verify exit-125 error capture, bounded output, and non-blocking handling of large stderr.
- **Updated:** 2 related cases now verify portable faulty-command error capture and Slack diagnostic ordering.
- **Deleted:** None.

## Validation

- `make pytest`: 166 passed; 80.17% coverage.
- `make flake8`: passed.
- `make black`: passed.
- `git diff --check`: passed.
